### PR TITLE
Relax dependencies to build with stackage=19.33 and stackage=20.11

### DIFF
--- a/language-tl.cabal
+++ b/language-tl.cabal
@@ -22,11 +22,11 @@ source-repository head
 
 common common-attrs
   build-depends:
-    , aeson        >=1.4.7 && <1.6
+    , aeson        >=1.4.7
     , base         >=4.10  && <5
     , bytestring   >=0.10  && <0.12
     , containers   ^>=0.6
-    , megaparsec   ^>=9.0
+    , megaparsec   >= 8.0.0
     , optics-core
     , optics-th
     , text         ^>=1.2.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack/stack-20.11.yaml

--- a/stack/stack-18.28.yaml
+++ b/stack/stack-18.28.yaml
@@ -1,0 +1,4 @@
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+packages:
+- .

--- a/stack/stack-19.33.yaml
+++ b/stack/stack-19.33.yaml
@@ -1,0 +1,4 @@
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/33.yaml
+packages:
+- .

--- a/stack/stack-20.11.yaml
+++ b/stack/stack-20.11.yaml
@@ -1,0 +1,4 @@
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/11.yaml
+packages:
+- .


### PR DESCRIPTION
No code changes were necessary; source builds just fine with newer
versions of dependencies.
